### PR TITLE
Remove unnecessary to_string within println

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -418,7 +418,7 @@
 //! assert_eq!(e.to_string(), "invalid toolchain name: 'xyzzy'");
 //!
 //! // Get the full cause and backtrace:
-//! println!("{}", e.display_chain().to_string());
+//! println!("{}", e.display_chain());
 //! //     Error: invalid toolchain name: 'xyzzy'
 //! //     Caused by: invalid digit found in string
 //! //     stack backtrace:


### PR DESCRIPTION
I noticed a small error in the documentation. `to_string` is not necessary when in the context of a `println!` call, because both `to_string` and the `{}` format specifier use the Display trait. In other words, `to_string` is implied. It's not really a big deal, but I do think it is a mistake.